### PR TITLE
Update local.conf

### DIFF
--- a/graph-builder/src/test/resources/integration/local.conf
+++ b/graph-builder/src/test/resources/integration/local.conf
@@ -33,8 +33,8 @@ service {
     host = "localhost"
 
     threads {
-        min = 1
-        max = 5
+        min = 5
+        max = 10
         idle.timeout = 12000
     }
 


### PR DESCRIPTION
We are unable to build the project within our ci/cd pipeline. We are getting the error shown below. This update fixes the issue.

14:11:51 [36mDiscovery completed in 930 milliseconds.[0m
14:11:51 [36mRun starting. Expected test count is: 3[0m
14:11:51 [32mEdgeStatsSerdeSpec:[0m
14:11:51 [32mEdgeStateSerde [0m
14:11:51 [32mAppConfigurationSpec:[0m
14:11:51 [32mloading application configuration[0m
14:11:51 [32mAppSpec:[0m
14:12:09 [31mcom.expedia.www.haystack.service.graph.graph.builder.AppSpec *** ABORTED ***[0m
14:12:09 [31m  java.lang.IllegalStateException: Insufficient configured threads: required=5 < max=5 for QueuedThreadPool[qtp2088969892]@7c8326a4{STARTED,1<=1<=5,i=1,q=0}[0m
14:12:09 [31m  at org.eclipse.jetty.util.thread.ThreadPoolBudget.check(ThreadPoolBudget.java:149)[0m
14:12:09 [31m  at org.eclipse.jetty.util.thread.ThreadPoolBudget.leaseTo(ThreadPoolBudget.java:130)[0m
14:12:09 [31m  at org.eclipse.jetty.util.thread.ThreadPoolBudget.leaseFrom(ThreadPoolBudget.java:175)[0m
14:12:09 [31m  at org.eclipse.jetty.server.AbstractConnector.doStart(AbstractConnector.java:278)[0m
14:12:09 [31m  at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:81)[0m
14:12:09 [31m  at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:244)[0m
14:12:09 [31m  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)[0m
14:12:09 [31m  at org.eclipse.jetty.server.Server.doStart(Server.java:398)[0m
14:12:09 [31m  at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)[0m
14:12:09 [31m  at com.expedia.www.haystack.service.graph.graph.builder.service.HttpService.start(HttpService.scala:61)[0m
14:12:09 [31m  ...[0m
14:12:09 [36mRun completed in 16 seconds, 685 milliseconds.[0m
14:12:09 [36mTotal number of tests run: 0[0m
14:12:09 [36mSuites: completed 3, aborted 1[0m
14:12:09 [36mTests: succeeded 0, failed 0, canceled 0, ignored 0, pending 0[0m
14:12:09 [31m*** 1 SUITE ABORTED ***