### PR TITLE
Allow application server in config

### DIFF
--- a/graph-builder/src/main/scala/com.expedia.www.haystack.service.graph.graph.builder/config/AppConfiguration.scala
+++ b/graph-builder/src/main/scala/com.expedia.www.haystack.service.graph.graph.builder/config/AppConfiguration.scala
@@ -77,8 +77,9 @@ class AppConfiguration(resourceName: String) {
     val streamProps = new Properties
     addProps(streamsConfig, streamProps)
     // add stream application server config
-    streamProps.setProperty(StreamsConfig.APPLICATION_SERVER_CONFIG,
-      s"${config.getString("service.host")}:${config.getInt("service.http.port")}")
+    if (StringUtils.isBlank(streamProps.getProperty(StreamsConfig.APPLICATION_SERVER_CONFIG))) {
+      streamProps.setProperty(StreamsConfig.APPLICATION_SERVER_CONFIG, s"${config.getString("service.host")}:${config.getInt("service.http.port")}")
+    }
 
     if (kafka.hasPath("rocksdb")) {
       CustomRocksDBConfig.setRocksDbConfig(kafka.getConfig("rocksdb"))

--- a/graph-builder/src/test/resources/test/test_application_server_set.conf
+++ b/graph-builder/src/test/resources/test/test_application_server_set.conf
@@ -1,0 +1,57 @@
+health.status.path = "/app/isHealthy"
+
+kafka {
+  close.timeout.ms = 30000
+
+  streams {
+    application.id = "haystack-service-graph-graph-builder"
+    application.server = "127.0.0.1:1002"
+    bootstrap.servers = "localhost:9092"
+    num.stream.threads = 4
+    request.timeout.ms = 60000
+    commit.interval.ms = 3000
+    auto.offset.reset = latest
+    timestamp.extractor = "org.apache.kafka.streams.processor.WallclockTimestampExtractor"
+  }
+
+  rocksdb {
+    block.cache.size = 16777216
+    block.size = 16384
+    cache.index.and.filter.blocks = true
+    max.write.buffer.number = 2
+  }
+
+  consumer {
+    topic = "graph-nodes"
+  }
+
+  producer {
+    topic = "service-graph"
+  }
+
+  aggregate {
+    window.sec = 3600
+    retention.days = 3
+  }
+}
+
+service {
+  host = "localhost"
+  threads {
+    min = 1
+    max = 5
+    idle.timeout = 12000
+  }
+
+  http {
+    port = 8080
+    idle.timeout = 12000
+  }
+
+  client {
+    connection.timeout = 1000
+    socket.timeout = 1000
+  }
+}
+
+haystack.graphite.host = "monitoring-influxdb-graphite.kube-system.svc"

--- a/graph-builder/src/test/scala/com/expedia/www/haystack/service/graph/graph/builder/config/AppConfigurationSpec.scala
+++ b/graph-builder/src/test/scala/com/expedia/www/haystack/service/graph/graph/builder/config/AppConfigurationSpec.scala
@@ -20,6 +20,7 @@ package com.expedia.www.haystack.service.graph.graph.builder.config
 import com.expedia.www.haystack.service.graph.graph.builder.TestSpec
 import com.expedia.www.haystack.service.graph.graph.builder.config.entities.CustomRocksDBConfig
 import com.typesafe.config.ConfigException
+import org.apache.kafka.streams.StreamsConfig
 import org.apache.kafka.streams.processor.WallclockTimestampExtractor
 import org.rocksdb.{BlockBasedTableConfig, Options}
 
@@ -95,6 +96,18 @@ class AppConfigurationSpec extends TestSpec {
       blockConfig.blockSize() shouldBe 16384l
       blockConfig.cacheIndexAndFilterBlocks() shouldBe true
       rocksDbOptions.maxWriteBufferNumber() shouldBe 2
+      config.kafkaConfig.streamsConfig.values().get(StreamsConfig.APPLICATION_SERVER_CONFIG).toString shouldBe "localhost:8080"
+    }
+
+    it("should allow for the application server to be set in the config file") {
+      Given("a test configuration file")
+      val file = "test/test_application_server_set.conf"
+
+      When("Application configuration is loaded and KafkaConfiguration is obtained")
+      val config = new AppConfiguration(file)
+
+      Then("it should load the application.server expected")
+      config.kafkaConfig.streamsConfig.values().get(StreamsConfig.APPLICATION_SERVER_CONFIG).toString shouldBe "127.0.0.1:1002"
     }
   }
 }


### PR DESCRIPTION
Our infrastructure maps the ports differently. We want the http server to still spin up on port 8080 however we need other services to communicate with us on the port exposed externally. This update will allow us to define the host:port combination to accomplish.