### PR TITLE
Upgrade Jetty to remove security vulnerability;

### DIFF
--- a/node-finder/build/docker/jmxtrans-agent.xml
+++ b/node-finder/build/docker/jmxtrans-agent.xml
@@ -6,8 +6,6 @@
             <query objectName="java.lang:type=Memory" attribute="HeapMemoryUsage" key="committed" resultAlias="jvm.heapMemoryUsage.committed"/>
         <query objectName="java.lang:type=Memory" attribute="NonHeapMemoryUsage" key="used" resultAlias="jvm.nonHeapMemoryUsage.used"/>
         <query objectName="java.lang:type=Memory" attribute="NonHeapMemoryUsage" key="committed" resultAlias="jvm.nonHeapMemoryUsage.committed"/>
-        <query objectName="java.lang:type=GarbageCollector,name=ParNew" resultAlias="gc.young.#attribute#"/>
-        <query objectName="java.lang:type=GarbageCollector,name=ConcurrentMarkSweep" resultAlias="gc.old.#attribute#"/>
         <query objectName="java.lang:type=ClassLoading" attribute="LoadedClassCount" resultAlias="jvm.loadedClasses"/>
         <query objectName="java.lang:type=Threading" attribute="ThreadCount" resultAlias="jvm.thread"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <json4s.version>3.5.3</json4s.version>
         <typesafe-config.version>1.3.1</typesafe-config.version>
         <haystack-commons.version>1.0.50</haystack-commons.version>
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.11.v20180605</jetty.version>
         <apache.httpcomponents.version>4.2.5</apache.httpcomponents.version>
         <msgpack.version>0.8.13</msgpack.version>
         <httpclient.version>4.5.3</httpclient.version>
@@ -170,12 +170,6 @@
                 <groupId>com.expedia.www</groupId>
                 <artifactId>haystack-logback-metrics-appender</artifactId>
                 <version>${haystack.logback.metrics.appender.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.json4s</groupId>
-                <artifactId>json4s-jackson_${scala.major.minor.version}</artifactId>
-                <version>${json4s.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
see https://nvd.nist.gov/vuln/detail/CVE-2018-12538.
Documented in issue https://github.com/ExpediaDotCom/haystack-service-graph/issues/62.
Also removed two CMS GC metrics (we're now using G1 GC)
and a duplicated dependency.