### PR TITLE
Back to correct version of scoverage plugin. Rewrite LightSpan equals

### DIFF
--- a/graph-builder/pom.xml
+++ b/graph-builder/pom.xml
@@ -55,11 +55,6 @@
             <artifactId>httpclient</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.json4s</groupId>
-            <artifactId>json4s-jackson_${scala.major.minor.version}</artifactId>
-        </dependency>
-
         <!-- kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <scalatest.version>3.0.3</scalatest.version>
         <grpc.version>1.7.1</grpc.version>
         <netty.handler.version>4.1.16.Final</netty.handler.version>
-        <scoverage.plugin.version>1.4.0-M5</scoverage.plugin.version>
+        <scoverage.plugin.version>1.3.0</scoverage.plugin.version>
 
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>


### PR DESCRIPTION
methods so that the scoverage:report goal will work (equals was seeing
a NullPointerException) based on best practices in "Programming in
Scala" and "Scala Cookbook" (see
https://alvinalexander.com/scala/how-to-define-equals-hashcode-methods-in-scala-object-equality)