### PR TITLE
Make the parameter for listObjectsBatchSize in S3SnapshotStore optional,

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 2019-01-23 1.0.9
+  * Make the parameter for listObjectsBatchSize in S3SnapshotStore optional, as it's only needed when calling write
+
 ## 2019-01-23 1.0.8
   * Remove Main companion object (it wasn't really needed) 
   * Allow URL to be specified as a parameter instead of being hard coded

--- a/graph-builder/pom.xml
+++ b/graph-builder/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>haystack-service-graph</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.0.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/node-finder/pom.xml
+++ b/node-finder/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-service-graph</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.0.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-service-graph</artifactId>
-    <version>1.0.8-SNAPSHOT</version>
+    <version>1.0.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/snapshot-store/pom.xml
+++ b/snapshot-store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>haystack-service-graph</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>haystack-service-graph-snapshot-store</artifactId>

--- a/snapshot-store/src/main/scala/com/expedia/www/haystack/service/graph/snapshot/store/FileSnapshotStore.scala
+++ b/snapshot-store/src/main/scala/com/expedia/www/haystack/service/graph/snapshot/store/FileSnapshotStore.scala
@@ -32,7 +32,7 @@ class FileSnapshotStore(val directoryName: String) extends SnapshotStore {
   /**
     * Returns a FileSnapshotStore using the directory name specified
     *
-    * @param constructorArguments constructorArguments(0) must specify the directory to which snapshots will be stored
+    * @param constructorArguments constructorArguments[0] must specify the directory to which snapshots will be stored
     * @return the concrete FileSnapshotStore to use
     */
   override def build(constructorArguments: Array[String]): SnapshotStore = {

--- a/snapshotter/pom.xml
+++ b/snapshotter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>haystack-service-graph</artifactId>
         <groupId>com.expedia.www</groupId>
-        <version>1.0.8-SNAPSHOT</version>
+        <version>1.0.9-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
as it's only needed when calling write